### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
     "wrench/wrench": "^2.0",
     "web-token/jwt-easy": "^2.2",
     "web-token/jwt-key-mgmt": "^2.2",
-    "web-token/jwt-signature-algorithm-eddsa": "^2.2",
-    "paragonie/sodium_compat": "1.20"
+    "web-token/jwt-signature-algorithm-eddsa": "^2.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0 || ^8.0",


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: 1.20`, but also `php: ^7.2 || ^8.0`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?